### PR TITLE
moved to go modules and moved to scratch image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,25 @@
-FROM golang:onbuild
+FROM golang:1.14.4-alpine3.11 as builder
+
+RUN apk add --update ca-certificates git
+
+ENV SRC github.com/segmentio/segment-proxy
+ENV CGO_ENABLED=0
+ENV GO111MODULE=on
+ENV GOOS=linux
+ENV GOARCH=amd64
+
+ARG VERSION
+
+COPY . /go/src/${SRC}
+WORKDIR /go/src/${SRC}
+
+RUn go build -a -installsuffix cgo -ldflags "-w -s -extldflags '-static' -X main.version=$VERSION" -o /proxy
+
+FROM scratch
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /proxy /proxy
+
 EXPOSE 8080
+
+ENTRYPOINT ["/proxy"]

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/segmentio/segment-proxy
+
+go 1.13
+
+require github.com/gorilla/handlers v0.0.0-20160228171604-ee54c7b44cab


### PR DESCRIPTION
This PR moves to go1.4, uses go modules and moves the docker image to a scratch image.