### PR TITLE
Update proxy to support analytics 2.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,9 +32,6 @@ func singleJoiningSlash(a, b string) string {
 func NewSegmentReverseProxy(cdn *url.URL, trackingAPI *url.URL) http.Handler {
 	director := func(req *http.Request) {
 		// Figure out which server to redirect to based on the incoming request.
-		// https://segment-cdn.dayforward.com/analytics-next/bundles/130.bundle.9457873b007a93e16765.js
-		// https://segment-cdn.dayforward.com/analytics-next/bundles/ajs-destination.bundle.c473a3426ccbc3cdfba0.js
-		// https://prod-segment-cdn.dayforward.com/next-integrations/integrations/facebook-pixel/2.11.4/facebook-pixel.dynamic.js.gz
 		var target *url.URL
 		switch {
 		case strings.HasPrefix(req.URL.String(), "/v1/projects"):

--- a/main.go
+++ b/main.go
@@ -32,10 +32,20 @@ func singleJoiningSlash(a, b string) string {
 func NewSegmentReverseProxy(cdn *url.URL, trackingAPI *url.URL) http.Handler {
 	director := func(req *http.Request) {
 		// Figure out which server to redirect to based on the incoming request.
+		// https://segment-cdn.dayforward.com/analytics-next/bundles/130.bundle.9457873b007a93e16765.js
+		// https://segment-cdn.dayforward.com/analytics-next/bundles/ajs-destination.bundle.c473a3426ccbc3cdfba0.js
+		// https://prod-segment-cdn.dayforward.com/next-integrations/integrations/facebook-pixel/2.11.4/facebook-pixel.dynamic.js.gz
 		var target *url.URL
-		if strings.HasPrefix(req.URL.String(), "/v1/projects") || strings.HasPrefix(req.URL.String(), "/analytics.js/v1") {
+		switch {
+		case strings.HasPrefix(req.URL.String(), "/v1/projects"):
+			fallthrough
+		case strings.HasPrefix(req.URL.String(), "/analytics.js/v1"):
+			fallthrough
+		case strings.HasPrefix(req.URL.String(), "/next-integrations"):
+			fallthrough
+		case strings.HasPrefix(req.URL.String(), "/analytics-next/bundles"):
 			target = cdn
-		} else {
+		default:
 			target = trackingAPI
 		}
 


### PR DESCRIPTION
With the introduction of Analytics 2.0, the proxy began to fail to load key parts of segment. 

This adds the two missing route prefixes for segment to properly load when using the proxy.